### PR TITLE
Changing variable named contents to content

### DIFF
--- a/docs/parse.md
+++ b/docs/parse.md
@@ -64,7 +64,7 @@ The parser file contains the set of rules used to parse the ```content``` and
 return JSON data.
 
 ### content
-The ```content``` arugment is a required argument.  It provides the data that
+The ```content``` argument is a required argument.  It provides the data that
 is parsed in order to generate the JSON data based on the rules in the parser
 file.
 

--- a/docs/parse.md
+++ b/docs/parse.md
@@ -6,11 +6,11 @@ that can be stored as facts for the host.
 The ```parse``` task performs the parsing based on a set of rules defined in a
 parser file that defines which values to extract from the output and how to
 assign them to fact keys.  The parser language accepts a number of directives
-that can be used to control how data is extracted and assigned to keys.  
+that can be used to control how data is extracted and assigned to keys.
 
 ## How to parse the output of a command
 The basic function of this role is to pass the output of the show command
-through a parser to transform the text into another format.  
+through a parser to transform the text into another format.
 
 ```
 ---
@@ -22,7 +22,7 @@ through a parser to transform the text into another format.
         tasks_from: parse
       vars:
         parser: files/show_version.yaml
-        contents: "{{ lookup('file', 'output/ios/show_version.txt') }}"
+        content: "{{ lookup('file', 'output/ios/show_version.txt') }}"
 ```
 
 ## How to use TextFSM as the parsing engine
@@ -42,7 +42,7 @@ For example:
         tasks_from: parse
       vars:
         parser: files/show_version.yaml
-        contents: "{{ lookup('file', 'output/ios/show_version.txt') }}"
+        content: "{{ lookup('file', 'output/ios/show_version.txt') }}"
         parser_engine: textfsm
 ```
 
@@ -60,11 +60,11 @@ task.
 
 ### parser
 The ```parser``` argument is required and defines the path to the parser file.
-The parser file contains the set of rules used to parse the ```contents``` and
+The parser file contains the set of rules used to parse the ```content``` and
 return JSON data.
 
-### contents
-The ```contents``` arugment is a required argument.  It provides the data that
+### content
+The ```content``` arugment is a required argument.  It provides the data that
 is parsed in order to generate the JSON data based on the rules in the parser
 file.
 

--- a/includes/text_parser.yaml
+++ b/includes/text_parser.yaml
@@ -7,5 +7,5 @@
 - name: parse cli output and return facts using text_parser
   text_parser:
     file: "{{ filename }}"
-    contents: "{{ contents }}"
+    content: "{{ content }}"
     name: "{{ fact_name | default(omit) }}"

--- a/includes/textfsm.yaml
+++ b/includes/textfsm.yaml
@@ -3,5 +3,5 @@
   textfsm:
     src: "{{ src | default(omit) }}"
     file: "{{ parser | default(omit) }}"
-    contents: "{{ contents }}"
+    content: "{{ content }}"
     name: "{{ fact_name | default(omit) }}"

--- a/tasks/parse.yaml
+++ b/tasks/parse.yaml
@@ -9,10 +9,10 @@
     msg: "invalid option for parser_engine"
   when: parser_engine is defined and parser_engine not in ['text_parser', 'textfsm']
 
-- name: validate the contents variable
+- name: validate the content variable
   fail:
-    msg: "missing required fact: contents"
-  when: contents is undefined
+    msg: "missing required fact: content"
+  when: content is undefined
 
 - name: run parser tasks
   include_tasks: "{{role_path }}/includes/{{ parser_engine | default('text_parser') }}.yaml"

--- a/tasks/run.yaml
+++ b/tasks/run.yaml
@@ -14,9 +14,9 @@
     command: "{{ command }}"
   register: command
 
-- name: set contents fact
+- name: set content fact
   set_fact:
-    contents: "{{ command.stdout }}"
+    content: "{{ command.stdout }}"
 
 - name: parse output and return facts
   include_tasks: parse.yaml


### PR DESCRIPTION
`content` was changed to singular in network-engine. Aligning this role with that change.
Fixes #3